### PR TITLE
Fixed typo in edit meeting form title modal

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -160,7 +160,7 @@ const Home = (props: Props) => {
                         </div>
                         <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                           <Dialog.Title as="h3" className="text-lg leading-6 font-medium text-gray-900">
-                            Add Meeting
+                            Edit Meeting
                           </Dialog.Title>
                           <Formik
                     initialValues={{


### PR DESCRIPTION
Changes:
Edit typo in edit modal modal 
Displays 'Edit Meeting' now in edit meeting modal